### PR TITLE
Remove depend on oxide and replace with Morph.Web

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -4,7 +4,6 @@ Priority: optional
 Maintainer: Michael Hall <mhall119@ubuntu.com>
 Build-Depends: cmake (>= 2.8.9),
                debhelper (>= 9),
-               liboxideqt-qmlplugin (>= 1.2.0),
                python3-all:any,
                python3-setuptools,
                qt5-default,
@@ -44,8 +43,8 @@ Description: Toolkit for Ubuntu HTML5 Apps
 Package: ubuntu-html5-ui-toolkit-examples
 Architecture: all
 Depends: libjs-jquery,
-         liboxideqt-qmlplugin (>= 1.2.0),
          qmlscene,
+         qml-module-morph-web,
          qtdeclarative5-qtquick2-plugin,
          ubuntu-html5-ui-toolkit (= ${binary:Version}),
          ${misc:Depends},
@@ -62,7 +61,6 @@ Depends: dpkg-dev,
          libautopilot-qt (>= 1.4),
          libjs-jquery,
          libqt5test5,
-         liboxideqt-qmlplugin (>= 1.2.0),
          python3-xlib,
          python3-autopilot,
          qmlscene,
@@ -81,8 +79,7 @@ Description: Autopilot tests for the Toolkit for Ubuntu HTML5 Apps
 Package: ubuntu-html5-container
 Architecture: any
 Multi-Arch: foreign
-Depends: liboxideqt-qmlplugin (>= 1.3.5),
-         qmlscene,
+Depends: qmlscene,
          qtdeclarative5-qtquick2-plugin,
          qtdeclarative5-ubuntu-ui-extras-browser-plugin,
          ubuntu-html5-ui-toolkit (= ${source:Version}),
@@ -97,7 +94,6 @@ Package: ubuntu-html5-container-autopilot
 Architecture: all
 Depends: libautopilot-qt (>= 1.4),
          libqt5test5,
-         liboxideqt-qmlplugin (>= 1.2.0),
          qtdeclarative5-qtquick2-plugin,
          ubuntu-html5-container (>= ${binary:Version}),
          python3-autopilot,

--- a/examples/html5-theme/ui-gallery/qml/main.qml
+++ b/examples/html5-theme/ui-gallery/qml/main.qml
@@ -20,7 +20,7 @@
  */
 
 import QtQuick 2.0
-import com.canonical.Oxide 1.0
+import Morph.Web 0.1
 
 Item {
      width: 800

--- a/src/ubuntu-html5-app-launcher/main.cpp
+++ b/src/ubuntu-html5-app-launcher/main.cpp
@@ -102,7 +102,7 @@ void usage()
 
 int main(int argc, char *argv[])
 {
-    // Enable compositing in oxide
+    // Enable compositing in QtWebEngine
     QCoreApplication::setAttribute(Qt::AA_ShareOpenGLContexts);
 
     QGuiApplication app(argc, argv);


### PR DESCRIPTION
This does not include ubuntu-html5-container, but this is long
deprecated and not something we use or even include in our current
rootfs.